### PR TITLE
fix a bug of that using 'All' options in getShape will only always compute MGW

### DIFF
--- a/R/getShape.R
+++ b/R/getShape.R
@@ -56,7 +56,7 @@ getShape <- function(filename, shapeType = 'All', parse = TRUE) {
     stopifnot( shapeType %in% c( opts, 'All' ) )
 
     if( shapeType != 'All' ) {
-        getDNAShape(filename, 'MGW')
+        getDNAShape(filename, shapeType)
 
     } else {
         getDNAShape(filename, 'MGW')


### PR DESCRIPTION
As title, it's an obvious bug.
